### PR TITLE
Fixed UTF8 share name issue

### DIFF
--- a/Scripts/Audit-Functions.psm1
+++ b/Scripts/Audit-Functions.psm1
@@ -205,11 +205,11 @@ Function Invoke-PSExecCommand {
     
     # Then tune a few properties we need
     $ScriptPath = $ScriptFileObject.Directory.FullName;
-    $ShareName  = ($ScriptFileObject.BaseName -replace "[^a-zA-Z]","") + "$";
+    $ShareName  = ($ScriptFileObject.BaseName -replace '[^a-zA-Z]','') + '$';
     $ScriptFile = $ScriptFileObject.Name;
 
     # Then we need to share the script path with the script name we parsed
-    [Void](New-SMBShare –Name $ShareName –Path $ScriptPath -FullAccess "Everyone");
+    [Void](New-SMBShare -Name $ShareName -Path $ScriptPath -FullAccess "Everyone");
 
     # Get the command built; Unrestricted policy is for PSv2 compatibility, the scope is this execution only
     $Command = @(


### PR DESCRIPTION
The share name was being corrupted when using the PSExec protocol. As it turns out this is because VSCode stored the file in UTF8 format - converting back to ANSI solved the issue.

Added single quotes around `$ShareName` variable construction for good measure, and added the `-Path` and `-Name` parameters back into the `New-SMBShare` cmdlet as these were trashed with garbage UTF8 characters.