### PR TITLE
Various fixes and enhancements

### DIFF
--- a/Filters/FILTERS.md
+++ b/Filters/FILTERS.md
@@ -181,3 +181,4 @@ _(Note: For IIS versions 5 and 6, use the `$_.IISConfigurationv5and6.*` property
 | SQL Instance Information | `$_.SQLServer` | ServerName<br /> InstanceName<br /> ConnectionIdentifier<br /> Databases<br /><br />_Databases objects enumerate to:_<br /> Name<br /> Owner<br /> CreatedDate<br /> CompatibilityLevel<br /> DBID<br /> Status<br /> Size<br /> |
 | Apache Virtual Hosts | `$_.ApacheVirtualHosts` | String[] of Virtual Hosts |
 | Tomcat Applications | `$_.TomcatApplications` | String[] of applications |
+| Networking connections | `$_.ConnectionInformation` | Protocol<br /> LocalAddress<br /> LocalPort<br /> RemoteAddress<br /> RemotePort<br /> State<br /> ProcessID<br /> ProcessName<br /> ProcessDescription<br /> ProcessProduct<br /> ProcessFileVersion<br /> ProcessExePath<br /> ProcessCompany<br /> |

--- a/Filters/FILTERS.md
+++ b/Filters/FILTERS.md
@@ -123,6 +123,7 @@ Click on the WMI class name for a full list of methods and properties from the M
 | [Win32_OperatingSystem](https://msdn.microsoft.com/en-us/library/aa394239(v=vs.85).aspx) | `$_.OS` |
 | [Win32_ComputerSystem](https://msdn.microsoft.com/en-us/library/aa394102(v=vs.85).aspx) | `$_.SystemInfo.SystemInfo` |
 | [Win32_BIOS](https://msdn.microsoft.com/en-us/library/aa394077(v=vs.85).aspx) | `$_.SystemInfo.BIOS` |
+| [Cim_Chassis](https://msdn.microsoft.com/en-us/library/aa387204(v=vs.85).aspx) | `$_.Hardware` |
 | [Win32_Processor](https://msdn.microsoft.com/en-us/library/aa394373(v=vs.85).aspx) | `$_.Compute` |
 | [Win32_PhysicalMemory](https://msdn.microsoft.com/en-us/library/aa394347(v=vs.85).aspx) | `$_.Memory.PhysicalMemory` |
 | [Win32_DiskDrive](https://msdn.microsoft.com/en-us/library/aa394132(v=vs.85).aspx) | `$_.Storage.PhysicalDisks` |

--- a/Filters/example.ps1
+++ b/Filters/example.ps1
@@ -246,6 +246,9 @@ $Filter.PSObject.Properties | Sort -Property Name | %{
         # Write out and set our warning trigger
         Write-ShellMessage -Message "There was an error attempting to compile data for '$Hostname' and write it to disk" -Type ERROR -ErrorRecord $_;
         $WarningTrigger = $True;
+
+        # Write to error log file
+        Write-ErrorLog -HostName $HostName -EventName "Compilation" -Exception $($_.Exception.Message);
     }
 }
 

--- a/Invoke-WindowsAudit.ps1
+++ b/Invoke-WindowsAudit.ps1
@@ -144,6 +144,10 @@ Param(
     [String]$Filter
 )
 
+# Start transcript
+$DateStamp = Get-Date -Format "ddMMyy_HHmmss";
+[Void](Start-Transcript ".\Windows-Audit-Transcript-$env:username-$DateStamp.log");
+
 # Run the gather phase if required
 if (!($CompileOnly.IsPresent)) {
     .\Scripts\Get-WindowsAuditData.ps1 `
@@ -158,6 +162,9 @@ if (!($CompileOnly.IsPresent)) {
 if ($Compile.IsPresent -or $CompileOnly.IsPresent) {
     .\Scripts\Compile-WindowsAuditData.ps1 -Filter $Filter;
 }
+
+# Stop transcript
+[Void](Stop-Transcript);
 
 # Fin
 Exit;

--- a/Scripts/Audit-Functions.psm1
+++ b/Scripts/Audit-Functions.psm1
@@ -200,43 +200,49 @@ Function Invoke-PSExecCommand {
         [Int]$SerialisationDepth = 5
     )
 
-    # Ok we need to get an object containing the properties we want
-    $ScriptFileObject = Get-Item $Script;
-    
-    # Then tune a few properties we need
-    $ScriptPath = $ScriptFileObject.Directory.FullName;
-    $ShareName  = ($ScriptFileObject.BaseName -replace '[^a-zA-Z]','') + '$';
-    $ScriptFile = $ScriptFileObject.Name;
+    # Trapped to take advantage of finally block
+    try {
+        # Ok we need to get an object containing the properties we want
+        $ScriptFileObject = Get-Item $Script;
+        
+        # Then tune a few properties we need
+        $ScriptPath = $ScriptFileObject.Directory.FullName;
+        $ShareName  = ($ScriptFileObject.BaseName -replace '[^a-zA-Z]','') + '$';
+        $ScriptFile = $ScriptFileObject.Name;
 
-    # Then we need to share the script path with the script name we parsed
-    [Void](New-SMBShare -Name $ShareName -Path $ScriptPath -FullAccess "Everyone");
+        # Then we need to share the script path with the script name we parsed
+        [Void](New-SMBShare -Name $ShareName -Path $ScriptPath -FullAccess "Everyone");
 
-    # Get the command built; Unrestricted policy is for PSv2 compatibility, the scope is this execution only
-    $Command = @(
-        'Set-ExecutionPolicy Unrestricted -ErrorAction SilentlyContinue;',
-        $('$ScriptBlock = [ScriptBlock]::Create($(Get-Content "\\{0}\{1}\{2}" | Out-String));' -f $env:COMPUTERNAME,$ShareName,$ScriptFile),
-        '$AuditResult = $ScriptBlock.Invoke();',
-        'return [System.Management.Automation.PSSerializer]::Serialize($AuditResult,5);'
-    ) -Join "";
+        # Get the command built; Unrestricted policy is for PSv2 compatibility, the scope is this execution only
+        $Command = @(
+            'Set-ExecutionPolicy Unrestricted -ErrorAction SilentlyContinue;',
+            $('$ScriptBlock = [ScriptBlock]::Create($(Get-Content "\\{0}\{1}\{2}" | Out-String));' -f $env:COMPUTERNAME,$ShareName,$ScriptFile),
+            '$AuditResult = $ScriptBlock.Invoke();',
+            'return [System.Management.Automation.PSSerializer]::Serialize($AuditResult,5);'
+        ) -Join "";
 
-    # And get the expression ready
-    $Expression = "psexec \\$ComputerName  cmd /c powershell -Command $Command";
-    
-    # Invoke the PSExec command
-    $RawOutput = Invoke-Expression $Expression;
+        # And get the expression ready
+        $Expression = "psexec \\$ComputerName  cmd /c powershell -Command $Command";
+        
+        # Invoke the PSExec command
+        $RawOutput = Invoke-Expression $Expression;
 
-    # Clean up the output
-    $RawOutput = $RawOutput -replace "PsExec v(.*) - Execute processes remotely","";
-    $RawOutput = $RawOutput -replace "Copyright \(C\) (.*) Mark Russinovich","";
-    $RawOutput = $RawOutput -replace "Sysinternals - www.sysinternals.com","";
-    $RawOutput = $RawOutput | ?{![String]::IsNullOrEmpty($_)};
-    [PSCustomObject]$Output = [System.Management.Automation.PSSerializer]::Deserialize($RawOutput);
+        # Clean up the output
+        $RawOutput = $RawOutput -replace "PsExec v(.*) - Execute processes remotely","";
+        $RawOutput = $RawOutput -replace "Copyright \(C\) (.*) Mark Russinovich","";
+        $RawOutput = $RawOutput -replace "Sysinternals - www.sysinternals.com","";
+        $RawOutput = $RawOutput | ?{![String]::IsNullOrEmpty($_)};
+        [PSCustomObject]$Output = [System.Management.Automation.PSSerializer]::Deserialize($RawOutput);
 
-    # Remove the share we created before exec()
-    [Void](Remove-SMBShare -Name $ShareName -Force);
-
-    # And return the goods
-    return $Output;
+        # And return the goods
+        return $Output;
+    }
+    catch {
+        throw $Error[0];
+    }
+    finally {
+        [Void](Get-SMBShare -Name $ShareName -ErrorAction SilentlyContinue | Remove-SMBShare -Force);
+    }
 }
 
 # Writes pretty log messages

--- a/Scripts/Audit-Functions.psm1
+++ b/Scripts/Audit-Functions.psm1
@@ -283,3 +283,34 @@ Function Write-ShellMessage {
     # And write out
     Write-Host $Output -ForegroundColor $C;
 }
+
+# Writes error log messages to file
+Function Write-ErrorLog {
+    [Cmdletbinding()]
+    Param(
+        [Parameter(Mandatory=$True)]
+        [ValidateNotNullOrEmpty()]
+        [String]$Hostname,
+        [Parameter(Mandatory=$True)]
+        [ValidateNotNullOrEmpty()]
+        [String]$EventName,
+        [Parameter(Mandatory=$True)]
+        [ValidateNotNullOrEmpty()]
+        [String]$Exception
+    )
+
+    # Get a datestamp sorted
+    $DateStamp = Get-Date -Format "dd/MM/yy HH:mm:ss";
+
+    # Build our message output
+    $Output = [String]::Format("[{0}] [{1}] [{2}]: {3}",$DateStamp,$HostName,$Type,$Exception);
+    
+    # Check if our errors file exists and create if needed
+    $ErrorsFile = ".\errors.log";
+    if (!(Test-Path $ErrorsFile)) {
+        [Void](New-Item $ErrorsFile -ItemType File);
+    }
+
+    # Add the content to the file
+    Add-Content -Path $ErrorsFile -Value $Output;
+}

--- a/Scripts/Audit-ScriptBlock.ps1
+++ b/Scripts/Audit-ScriptBlock.ps1
@@ -942,20 +942,14 @@ catch {
 
 #---------[ Apache Virtual Hosts ]---------
 try {
-    if (Get-Service | ?{$_.Name -like "*Apache*" -and $_.Name -notlike "*Tomcat*"}) {
+    if (Get-Process "httpd") {
         Write-ShellMessage -Message "Gathering Apache Virtual Host information" -Type INFO;
 
-        # Get the Apache install and httpd.exe paths
-        $ApachePath = $((Get-ChildItem "C:\Program Files (x86)\*Apache*").FullName);
-        $Httpd      = $((Get-ChildItem $ApachePath "httpd.exe" | Select -First 1).FullName);
+        # Get the Apache httpd.exe path
+        $Httpd = (Get-Process "httpd").Path;
 
-        if ($Httpd) {
-            # Add a collection containing our Apache tree to the hostinfo object
-            Add-HostInformation -Name ApacheVirtualHosts -Value $((Invoke-Expression "$httpd -S").Split("`r`n"));
-        }
-        else {
-            throw "Couldn't locate Apache httpd.exe";
-        }
+        # Add a collection containing our Apache tree to the hostinfo object
+        Add-HostInformation -Name ApacheVirtualHosts -Value $((Invoke-Expression "$httpd -S").Split("`r`n"));
     }
 }
 catch {
@@ -968,7 +962,7 @@ try {
         Write-ShellMessage -Message "Gathering Tomcat application information" -Type INFO;
 
         # Add a collection containing our Tomcat tree to the hostinfo object
-        $TomcatApplications = $((New-Object System.Net.WebClient).DownloadString("http://localhost:8080/manager/text/list").Split("`r`n"));
+        $TomcatApplications = $((New-Object System.Net.WebClient).DownloadString("http://localhost:8080/manager/list").Split("`r`n"));
         Add-HostInformation -Name TomcatApplications -Value $TomcatApplications;
     }
 }

--- a/Scripts/Audit-ScriptBlock.ps1
+++ b/Scripts/Audit-ScriptBlock.ps1
@@ -293,6 +293,15 @@ catch {
     Write-ShellMessage -Message "Error gathering BIOS information" -Type ERROR -ErrorRecord $Error[0];
 }
 
+#---------[ Chassis/Hardware ]---------
+try {
+    Write-ShellMessage -Message "Gathering hardware information" -Type INFO;
+    Add-HostInformation -Name Hardware -Value $(Get-WMIObject -Class "Cim_Chassis" | Select -Property *);
+}
+catch {
+    Write-ShellMessage -Message "Error gathering hardware information" -Type ERROR -ErrorRecord $Error[0];
+}
+
 #---------[ System ]---------
 try {
     Write-ShellMessage -Message "Gathering system information" -Type INFO;

--- a/Scripts/Audit-ScriptBlock.ps1
+++ b/Scripts/Audit-ScriptBlock.ps1
@@ -942,7 +942,7 @@ catch {
 
 #---------[ Apache Virtual Hosts ]---------
 try {
-    if (Get-Process "httpd") {
+    if ($(try{[Void](Get-Process "httpd")}catch{$false})) {
         Write-ShellMessage -Message "Gathering Apache Virtual Host information" -Type INFO;
 
         # Get the Apache httpd.exe path

--- a/Scripts/Get-WindowsAuditData.ps1
+++ b/Scripts/Get-WindowsAuditData.ps1
@@ -222,6 +222,9 @@ ForEach ($Computer in $Computers) {
         # Write out and set our warning trigger
         Write-ShellMessage -Message "There was a problem gathering information from computer '$HostName'" -Type WARNING -ErrorRecord $_;
         $WarningTrigger = $True;
+
+        # Write to error log file
+        Write-ErrorLog -HostName $HostName -EventName "Gather" -Exception $($_.Exception.Message);
     }
 }
 
@@ -262,6 +265,9 @@ $Output | %{
         # Write out and set our warning trigger
         Write-ShellMessage -Message "There was an error attempting to serialise data for '$Hostname' and write it to disk" -Type ERROR -ErrorRecord $_;
         $WarningTrigger = $True;
+
+        # Write to error log file
+        Write-ErrorLog -HostName $HostName -EventName "WriteToDisk" -Exception $($_.Exception.Message);
     }
 }
 

--- a/Scripts/Get-WindowsAuditData.ps1
+++ b/Scripts/Get-WindowsAuditData.ps1
@@ -196,8 +196,17 @@ ForEach ($Computer in $Computers) {
             }
             else {
                 # Execute the command using the default credential
-                Write-ShellMessage -Message "Connecting to '$HostName' using protocol '$Protocol' on port '$Port'" -Type INFO;
-                $HostInformation = Invoke-Command -ComputerName $Hostname -Port $Port -ScriptBlock $ScriptBlock;
+                try {
+                    Write-ShellMessage -Message "Connecting to '$HostName' using protocol '$Protocol' on port '$Port'" -Type INFO;
+                    $HostInformation = Invoke-Command -ComputerName $Hostname -Port $Port -ScriptBlock $ScriptBlock;
+                }
+                catch {
+                    Write-ShellMessage -Message "Connection to '$HostName' failed" -Type ERROR -ErrorRecord $_;
+
+                    # Fallback to PSExec instead
+                    Write-ShellMessage -Message "Attempting fallback connection: Connecting to '$HostName' using protocol 'PSExec'" -Type INFO;
+                    $HostInformation = Invoke-PSExecCommand -ComputerName $Hostname -Script $ScriptBlockPath -SerialisationDepth $SerialisationDepth; 
+                }
             }
         }
         else {
@@ -209,8 +218,17 @@ ForEach ($Computer in $Computers) {
             }
             else {
                 # Execute the command using the default credential
-                Write-ShellMessage -Message "Connecting to '$HostName' using protocol '$Protocol'" -Type INFO;
-                $HostInformation = Invoke-Command -ComputerName $Hostname -ScriptBlock $ScriptBlock;
+                try {
+                    Write-ShellMessage -Message "Connecting to '$HostName' using protocol '$Protocol'" -Type INFO;
+                    $HostInformation = Invoke-Command -ComputerName $Hostname -ScriptBlock $ScriptBlock;
+                }
+                catch {
+                    Write-ShellMessage -Message "Connection to '$HostName' failed" -Type ERROR -ErrorRecord $_;
+
+                    # Fallback to PSExec instead
+                    Write-ShellMessage -Message "Attempting fallback connection: Connecting to '$HostName' using protocol 'PSExec'" -Type INFO;
+                    $HostInformation = Invoke-PSExecCommand -ComputerName $Hostname -Script $ScriptBlockPath -SerialisationDepth $SerialisationDepth; 
+                }
             }
         }
 


### PR DESCRIPTION
Added new networking sessions check to include all information on `ESTABLISHED` and `CLOSE_WAIT` connections. This will help investigate third party applications with custom configuration. Also updated documentation to include the mappings for this.

Added a Start-Job wrapper around the IIS configuration gathering, this allows a strict timeout on the WebAdministration module import. (Set at 2 minutes.)

Added `Cim_Chassis` WMI class to the gathering phase, and included link in the documentation. This allows more granular recovery of hardware information like the Asset Tag (not to be confused with the _Service Tag_)

Fixed Apache/Tomcat gathering issues; Given the ambiguity of install location and configuration of Apache on Windows, installed status and `httpd` bin path are now gathered from a `System.Diagnostics.Process` object instead of through the Windows file system. Tomcat had an issue where the `/text/` subdirectory does not always exist on the management site, or has permissions issues. Resorted to `/manager/list` subdirectory instead.

Fixed share release issue on PSExec protocol by using a try/catch/finally block.

Added individual error tracking; an `errors.log` file will now appear containing a list of errors that have occurred, which sections and which hosts they relate to. This should make identifying machines where the gathering has failed much easier. In addition to this, also added a top-level transcript which gathers the entire log output from each run.

Changed the Get-WindowsAuditData script slightly, if WinRM connectivity fails it will try PSExec as an alternative before throwing an exception.


