### PR TITLE
Johngeorge/more fixes and enhancements

### DIFF
--- a/Scripts/Audit-Functions.psm1
+++ b/Scripts/Audit-Functions.psm1
@@ -222,7 +222,7 @@ Function Invoke-PSExecCommand {
         ) -Join "";
 
         # And get the expression ready
-        $Expression = "psexec \\$ComputerName  cmd /c powershell -Command $Command";
+        $Expression = "psexec -i \\$ComputerName  cmd /c powershell -Command $Command";
         
         # Invoke the PSExec command
         $RawOutput = Invoke-Expression $Expression;

--- a/Scripts/Audit-ScriptBlock.ps1
+++ b/Scripts/Audit-ScriptBlock.ps1
@@ -911,12 +911,12 @@ try {
         
                 # Parse and add to the DBInfoCollection
                 $DBInfoCollection += $(New-Object PSCustomObject -Property @{
-                    Name               = $DB.name.Trim();
-                    Size               = $DB.db_size.Trim();
-                    Owner              = $DB.owner.Trim();
+                    Name               = $DB.name.ToString().Trim();
+                    Size               = $DB.db_size.ToString().Trim();
+                    Owner              = $DB.owner.ToString().Trim();
                     DBID               = $DB.dbid;
                     CreatedDate        = [Datetime]$DB.created;
-                    Status             = $DB.status.Trim();
+                    Status             = $DB.status.ToString().Trim();
                     CompatibilityLevel = $DB.compatibility_level;
                 });
             


### PR DESCRIPTION
Added interactive switch to PSExec calls, this should stop the script from hanging when using PSExec.

Added explicit casts to string for all `SP_HELPDB` outputs, as on older instances of PowerShell the SQL data types don't always get coerced to strings.