### PR TITLE
Fixed missing variable for serialisation depth in Invoke-PSExecCommand

### DIFF
--- a/Scripts/Audit-Functions.psm1
+++ b/Scripts/Audit-Functions.psm1
@@ -218,7 +218,7 @@ Function Invoke-PSExecCommand {
             'Set-ExecutionPolicy Unrestricted -ErrorAction SilentlyContinue;',
             $('$ScriptBlock = [ScriptBlock]::Create($(Get-Content "\\{0}\{1}\{2}" | Out-String));' -f $env:COMPUTERNAME,$ShareName,$ScriptFile),
             '$AuditResult = $ScriptBlock.Invoke();',
-            'return [System.Management.Automation.PSSerializer]::Serialize($AuditResult,5);'
+            $('return [System.Management.Automation.PSSerializer]::Serialize($AuditResult,{0});' -f $SerialisationDepth)
         ) -Join "";
 
         # And get the expression ready


### PR DESCRIPTION
Variable had been placed through however not threaded into the command string build, now done. Allows control over the serialisation depth properly.