### PR TITLE
Fixed import issue on 2008 r2 for the WebAdministration module

### DIFF
--- a/Scripts/Audit-ScriptBlock.ps1
+++ b/Scripts/Audit-ScriptBlock.ps1
@@ -636,7 +636,12 @@ try {
             Set-ExecutionPolicy Unrestricted -Force;
 
             # Get the WebAdministration module imported
-            Import-Module WebAdministration;
+            Import-Module WebAdministration -Force;
+
+            # Slight wait to fix any import latency issues
+            Try{
+                [Void](Get-WebSite);
+            } Catch [System.IO.FileNotFoundException]{}
 
             # Now, we need to explicitly cast the outputs of the following
             # to PSCustomObjects as the IISConfigurationElement and other


### PR DESCRIPTION
Added try catch as per fix for 2008 r2 Import-Module issue.

https://help.octopusdeploy.com/discussions/problems/5172-error-using-get-website-in-predeploy-because-of-filenotfoundexception