### PR TITLE
Johngeorge/more fixes and enhancements

### DIFF
--- a/Scripts/Audit-Functions.psm1
+++ b/Scripts/Audit-Functions.psm1
@@ -225,7 +225,7 @@ Function Invoke-PSExecCommand {
         $Expression = "psexec -i \\$ComputerName  cmd /c powershell -Command $Command";
         
         # Invoke the PSExec command
-        Invoke-Expression $Expression;      
+        Invoke-Expression $Expression;
 
         # We need to get the cli.xml file and place it in output/rawdata;
         $CLIXMLFile = Get-ChildItem ".\Scripts\" "*.cli.xml" | Sort -Property CreationTime | Select -First 1;

--- a/Scripts/Audit-ScriptBlock.ps1
+++ b/Scripts/Audit-ScriptBlock.ps1
@@ -430,7 +430,8 @@ try {
         $ShareName = $_.Name;
         
         # Get some share permission information
-        $ShareInfo = Invoke-Expression "net share $ShareName";
+        $Expr = "net share '" + $ShareName + "'";
+        $ShareInfo = Invoke-Expression $Expr;
 
         # Clean it up
         $Permissions = (($ShareInfo | ?{$_ -like "Permission*" -or $_ -like " *"}) -join "");

--- a/Scripts/Compile-WindowsAuditData.ps1
+++ b/Scripts/Compile-WindowsAuditData.ps1
@@ -31,6 +31,10 @@ Param(
 
 #---------[ Global Declarations ]---------
 
+# Get the execution policy value and set to unrestructed
+$ExecutionPolicy = Get-ExecutionPolicy;
+Set-ExecutionPolicy Unrestricted -Force;
+
 # EAP to stop so we can trap errors in catch blocks
 $ErrorActionPreference = "Stop";
 
@@ -86,6 +90,9 @@ $CliXmlFilesToProcess | %{
     # And pass the result on to the correct filter for execution
     & $FilterPath -HostInformation $HostInformation;
 }
+
+#---------[ Set the exec policy back to what it was ]---------
+Set-ExecutionPolicy $ExecutionPolicy -Force;
 
 #---------[ Fin ]---------
 Exit;

--- a/Scripts/Get-WindowsAuditData.ps1
+++ b/Scripts/Get-WindowsAuditData.ps1
@@ -78,6 +78,10 @@ Param(
 
 #---------[ Global Declarations ]---------
 
+# Get the execution policy value and set to unrestructed
+$ExecutionPolicy = Get-ExecutionPolicy;
+Set-ExecutionPolicy Unrestricted -Force;
+
 # EAP to stop so we can trap errors in catch blocks
 $ErrorActionPreference = "Stop";
 
@@ -288,5 +292,8 @@ else {
     $FinalMessage = "Audit data gathering for $HostCount computers has completed successfully";
     Write-ShellMessage -Message $FinalMessage -Type SUCCESS;
 }
+
+#---------[ Set the exec policy back to what it was ]---------
+Set-ExecutionPolicy $ExecutionPolicy -Force;
 
 Exit;


### PR DESCRIPTION
Execution policy can cause ISE to throw warnings about this script's origin, applied Unrestricted policy during the session to hopefully fix this.

Fixed issue with parsing share names that contain spaces.