### PR TITLE
Fixed PSExec problems

### DIFF
--- a/Invoke-WindowsAudit.ps1
+++ b/Invoke-WindowsAudit.ps1
@@ -111,7 +111,7 @@ Param(
     [String]$Protocol = "WinRM",
 
     # PSCredential that will be used for WinRM to connect to the target machines
-    [Parameter(Mandatory=$False)]
+    [Parameter(Mandatory=$True)]
     [Parameter(ParameterSetName="InputFile")]
     [Parameter(ParameterSetName="ComputerList")]
     [ValidateNotNullOrEmpty()]

--- a/Scripts/Audit-ScriptBlock.ps1
+++ b/Scripts/Audit-ScriptBlock.ps1
@@ -1,10 +1,4 @@
-[Cmdletbinding()]
-Param(
-    [Parameter(Mandatory=$False)]
-    [Bool]$SurpressOutput,
-    [Parameter(Mandatory=$False)]
-    [String]$WritebackPath
-)
+Param([Switch]$X)
 
 #---------[ Declarations ]---------
 
@@ -155,13 +149,7 @@ Function Write-ShellMessage {
     }
 
     # And write out
-    if ($Script:SurpressOutput) {
-        $OutputFilePath = $Script:WritebackPath + "\$env:computername-logoutput.txt";
-        Add-Content -Path $OutputFilePath -Value $Output;
-    }
-    else {
-        Write-Host $Output -ForegroundColor $C;
-    }
+    Write-Host $Output -ForegroundColor $C;
 }
 
 # Alternative firewall rule gathering for Server 2003
@@ -1098,9 +1086,8 @@ Set-ExecutionPolicy $ExecutionPolicy -Force;
 
 #---------[ Return ]---------
 Write-ShellMessage -Message "Gathering completed" -Type SUCCESS;
-if ($Script:SurpressOutput) {
-    $ExportPath = $Script:WritebackPath + "\" + $env:COMPUTERNAME + ".cli.xml";
-    $HostInformation | Export-Clixml -Path $ExportPath -Force;
+if ($X.IsPresent) {
+    return [System.Management.Automation.PSSerializer]::Serialize($HostInformation,5);
 }
 else {
     return $HostInformation;

--- a/Scripts/Get-WindowsAuditData.ps1
+++ b/Scripts/Get-WindowsAuditData.ps1
@@ -68,7 +68,7 @@ Param(
     [String]$Protocol = "WinRM",
 
     # PSCredential that will be used for WinRM to connect to the target machines
-    [Parameter(Mandatory=$False)]
+    [Parameter(Mandatory=$True)]
     [PSCredential]$PSCredential,
 
     # Override for the ExportDepth to CLI XML
@@ -202,7 +202,7 @@ ForEach ($Computer in $Computers) {
         if ($Protocol -eq "PSExec") {
             # Ok let's call PSExec
             Write-ShellMessage -Message "Connecting to '$HostName' using protocol '$Protocol'" -Type INFO;
-            $HostInformation = Invoke-PSExecCommand -ComputerName $Hostname -Script $ScriptBlockPath -SerialisationDepth $SerialisationDepth; 
+            $HostInformation = Invoke-PSExecCommand -ComputerName $Hostname -Script $ScriptBlockPath -PSCredential $PSCredential;
         }
         elseif ($Port) {
             # Ok we're hitting a non standard port over WinRM, check if we're using a PSCredential and hit it
@@ -222,7 +222,7 @@ ForEach ($Computer in $Computers) {
 
                     # Fallback to PSExec instead
                     Write-ShellMessage -Message "Attempting fallback connection: Connecting to '$HostName' using protocol 'PSExec'" -Type INFO;
-                    $HostInformation = Invoke-PSExecCommand -ComputerName $Hostname -Script $ScriptBlockPath -SerialisationDepth $SerialisationDepth; 
+                    $HostInformation = Invoke-PSExecCommand -ComputerName $Hostname -Script $ScriptBlockPath -PSCredential $PSCredential;
                 }
             }
         }
@@ -244,7 +244,7 @@ ForEach ($Computer in $Computers) {
 
                     # Fallback to PSExec instead
                     Write-ShellMessage -Message "Attempting fallback connection: Connecting to '$HostName' using protocol 'PSExec'" -Type INFO;
-                    $HostInformation = Invoke-PSExecCommand -ComputerName $Hostname -Script $ScriptBlockPath -SerialisationDepth $SerialisationDepth; 
+                    $HostInformation = Invoke-PSExecCommand -ComputerName $Hostname -Script $ScriptBlockPath -PSCredential $PSCredential;
                 }
             }
         }


### PR DESCRIPTION
PSExec has been quite problematic so far, totally rewritten the `Invoke-PSExecCommand` function so that it is more robust. The way it works now is;

* Brings in the script content
* Removes all comments/blank lines
* Converts the content to a byte array
* Converts the byte array to a base64 string
* Breaks up the string into 210 char chunks (literal maximum for what we're about to do)
* Invokes PSExec to use `cmd /c "echo $chunk >> [guid].txt"` to write the chunk to a local temp file, repeats until file is delivered
* Invokes PSExec to reassemble the file
* Invokes PSExec to run the script capturing the output
* Removes the temp file and the script from the target machine
* Parses the data by taking all the shell output and writing it to the user's shell, removing the trash lines (PSExec output) and finally deserialises the XML back into a PSCustomObject
* Returns the PSObject as per the previous method

This seems like utter insanity, and it does take 2~ minutes to complete however this is the only sure fire way that it can be executed under the minimum conditions that PSExec needs to function.

Changed the Audit-Scriptblock to use an `-X` switch - this now simply changes the output from a PSCustomObject for transfer over WinRM, to plain serialised XML to return over PSExec.

Made PSCredential mandatory; as this allows us to use credentials for PSExec and will make the code much tidier rather than having different exec blocks for each condition x2 because PSCredential is in play. The majority of users will be using a non-them credential to connect anyway.