### PR TITLE
Multiple fixes

### DIFF
--- a/Examples/Computer-List-Example.psv
+++ b/Examples/Computer-List-Example.psv
@@ -1,5 +1,0 @@
-dev-server-01.mydomain.com|WinRM
-dev-server-02:55985|WinRM
-192.168.10.10|PSExec
-dev-server-04|WinRM
-dev-server-05|PSExec

--- a/Examples/Computer-List-Example.txt
+++ b/Examples/Computer-List-Example.txt
@@ -1,0 +1,5 @@
+dev-server-01.mydomain.com
+dev-server-02
+192.168.10.10
+10.68.189.10
+dev-server-05

--- a/Invoke-WindowsAudit.ps1
+++ b/Invoke-WindowsAudit.ps1
@@ -17,36 +17,18 @@
     provided; '.\Filters\Example.ps1'.
 
     .PARAMETER InputFile [String]
-    The path to a Pipe Separated Values file which will be parsed for target 
-    information on what instances to harvest audit data from. The per-line 
-    format should be:
-    
-        (hostname|ip):(port)|(protocol)
-    
-    An example of this file can be found here `..\Examples\Computer-List-Example.psv`.
+    The path to a file which will be parsed for target information on which 
+    instances to harvest audit data from. One computer name or IP address per
+    line.
 
     .PARAMETER Computers [String[]]
-    String array of computers to run this script on. If the computer value is 
-    a `host:port` or `ip:port` combination the specified port will be used for 
-    WinRM (only).
-
-    .PARAMETER Protocol [String: WinRM,PSExec]
-    The protocol to use for the target computers specified in the `$Computers` 
-    parameter. Valid options are `WinRM`|`PSExec` defaulting to `WinRM` if not 
-    specified.
+    String array of computers to run this script on. Used mutually exclusively
+    with InputFile as a shell-method of supplying instances to target.
 
     .PARAMETER PSCredential [PSCredential]
     PSCredential that will be used for WinRM communications. Must be valid on 
     the machines you're trying to connect to, defaults to the current user 
     identity.
-
-    .PARAMETER SerialisationDepth [Int: 2..8]
-    Override value for the serialisation depth to use when this script is using 
-    the `System.Management.Automation.PSSerializer` class. Defaults to `5` and 
-    range is limited to `2..8`; as anything less than `2` is useless, anything 
-    greater than `8` will generate a _very_ large (multi-gb) file and probably 
-    crash the targeted machine. Tweak this value only if the data you want is 
-    nested so low in the dataset it's not being enumerated in the output.
 
     .PARAMETER CompileOnly [Switch]
     This switch when present tells the script to do a compilation of the data
@@ -64,31 +46,26 @@
 
     .EXAMPLE
     .\Invoke-WindowsAudit.ps1 `
-            -InputFile ".\Input\MyComputerList.psv" `
+            -InputFile ".\Input\MyComputerList.txt" `
             -PSCredential $MyPSCredential `
             -Compile `
             -Filter "Example";
 
-    This will invoke an audit data gathering on the computers specified in the MyComputerList.psv
-    file, using the $MyPSCredential credential over machines targeted with WinRM, will then
-    compile the data into an Excel spreadsheet using the Example filter.
+    This will invoke an audit data gathering on the computers specified in the 
+    MyComputerList.txt file using the $MyPSCredential credential, and then compile 
+    the data into an Excel spreadsheet using the Example filter.
 
     .EXAMPLE
-    .\Invoke-WindowsAudit.ps1 `
-            -Computers "dev-test-01","dev-test-02" `
-            -Protocol PSExec;
+    .\Invoke-WindowsAudit.ps1 -Computers "dev-test-01","dev-test-02" -PSCredential $MyPSCredential;
 
     This will invoke an audit data gathering on the computers specified in the Computers
     parameter using the PSExec protocol. No further processing will take place after the data
     has been gathered.
 
     .EXAMPLE
-    .\Invoke-WindowsAudit.ps1 `
-            -CompileOnly `
-            -Filter "Example";
+    .\Invoke-WindowsAudit.ps1 -CompileOnly -Filter "Example";
 
     This will invoke a compilation of cached data using the supplied filter.
-
 #>
 
 [CmdletBinding(DefaultParameterSetName='InputFile')]
@@ -103,26 +80,12 @@ Param(
     [ValidateNotNullOrEmpty()]
     [String[]]$Computers,
 
-    # Protocol to use for connecting to the target machine
-    [Parameter(Mandatory=$False)]
-    [Parameter(ParameterSetName="InputFile")]
-    [Parameter(ParameterSetName="ComputerList")]
-    [ValidateSet("WinRM","PSExec")]
-    [String]$Protocol = "WinRM",
-
     # PSCredential that will be used for WinRM to connect to the target machines
     [Parameter(Mandatory=$True)]
     [Parameter(ParameterSetName="InputFile")]
     [Parameter(ParameterSetName="ComputerList")]
     [ValidateNotNullOrEmpty()]
     [PSCredential]$PSCredential,
-
-    # Override for the ExportDepth to CLI XML
-    [Parameter(Mandatory=$False)]
-    [Parameter(ParameterSetName="InputFile")]
-    [Parameter(ParameterSetName="ComputerList")]
-    [ValidateRange(2,8)]
-    [Int]$SerialisationDepth = 5,
 
     # This switch tells the script to only do the compile phase
     [Parameter(Mandatory=$False)]
@@ -153,9 +116,7 @@ if (!($CompileOnly.IsPresent)) {
     .\Scripts\Get-WindowsAuditData.ps1 `
                             -InputFile $InputFile `
                             -Computers $Computers `
-                            -Protocol $Protocol `
-                            -PSCredential $PSCredential `
-                            -SerialisationDepth $SerialisationDepth;
+                            -PSCredential $PSCredential;
 }
 
 # Run the compilation if required

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ The serialised data for servers will remain cached until another gathering opera
 Prerequisites
 ---------
 ##### Calling Client
-Connections over WinRM will require the [Windows Management Framework](https://support.microsoft.com/en-gb/help/968929/windows-management-framework-windows-powershell-2-0--winrm-2-0--and-bi) v2 as a minimum and a Windows credential that is valid on the target machine. For machines which have not got WinRM installed, you can use [PSExec](https://docs.microsoft.com/en-us/sysinternals/downloads/psexec) instead. If using PSExec you will need TCP port `445` open inbound, as the PowerShell scripts are shared over SMB with the Target Server.
+PowerShell v3 is the minimum client requirement. For machines which do not have WinRM installed/enabled, you can use PSExec which you can download [here](https://docs.microsoft.com/en-us/sysinternals/downloads/psexec).
 
 ##### Target Server
-Connections over WinRM will require the [Windows Management Framework](https://support.microsoft.com/en-gb/help/968929/windows-management-framework-windows-powershell-2-0--winrm-2-0--and-bi) v2 as a minimum with TCP port `5985` allowed from the calling client. Alternatively if using PSExec TCP port `445` needs to be opened. Powershell v2 and above has been verified, v1 has not been tested.
+Connections over WinRM will require the [Windows Management Framework](https://support.microsoft.com/en-gb/help/968929/windows-management-framework-windows-powershell-2-0--winrm-2-0--and-bi) v2 as a minimum with TCP port `5985` allowed from the calling client. Alternatively if using PSExec you can view a list of requirements [here](https://forum.sysinternals.com/psexec-could-not-start_topic3698_post11962.html#11962). Powershell v2 and above have been verified, v1 has not been tested.
 
 Usage
 ---------
@@ -20,21 +20,15 @@ There are a variety of sub scripts and modules however for simplicity the execut
 
 ##### Mandatory Parameters
 
- - `InputFile` - The path to a Pipe Separated Values file which will be parsed for target information on what instances to harvest audit data from. The per-line format should be `(hostname|ip):(port)|(protocol)`. An example of this file can be found here `.\Examples\Computer-List-Example.psv`.
+ - `InputFile` - The path to a text file which contains the computer list you wish to audit, one per line. An example of this file can be found here `.\Examples\Computer-List-Example.txt`. Mutually exclusive with the `Computers` parameter.
 
-     **or**
+ - `Computers` - String array of computers to audit. Mutually exclusive with the `InputFile` parameter.
 
- - `Computers` - String array of computers to run this script on. If the computer value is a `host:port` or `ip:port` combination the specified port will be used for WinRM (only).
+ - `PSCredential` - PSCredential that will be used to connect to the target machines. More information on how to use PSCredentials can be found [here](https://blogs.msdn.microsoft.com/koteshb/2010/02/12/powershell-how-to-create-a-pscredential-object/).
 
 ##### Optional Parameters
 
- - `Protocol` - The protocol to use for the target computers specified in the `$Computers` parameter. Valid options are `WinRM`|`PSExec` defaulting to `WinRM` if not specified. If WinRM fails to connect PSExec will be tried as a fallback.
-
- - `PSCredential` - PSCredential that will be used for WinRM communications. Must be valid on the machines you're trying to connect to, defaults to the current user identity.
-
- - `SerialisationDepth` - Override value for the serialisation depth to use when this script is using the `System.Management.Automation.PSSerializer` class. Defaults to `5` and range is limited to `2..8`; as anything less than `2` is useless, anything greater than `8` will generate a _very_ large (multi-gb) file and probably crash the targeted machine. Tweak this value only if the data you want is nested so low in the dataset it's not being enumerated in the output.
-
- - `Compile` - This switch when present tells the script to do a compilation of the data to an Excel spreadsheet. If this is supplied; the `Filter` parameter _must also_ be supplied.
+ - `Compile` - This switch when present tells the script to do a compilation of the just-gathered data to an Excel spreadsheet. If this is supplied; the `Filter` parameter _must also_ be supplied.
 
  - `CompileOnly` - This switch when present tells the script to do a compilation of the cached data to an Excel spreadsheet. If this is supplied; the `Filter` parameter _must also_ be supplied.
 
@@ -42,16 +36,20 @@ There are a variety of sub scripts and modules however for simplicity the execut
 
 ##### Examples
 
-This example will invoke an audit data gathering on the computers specified in the `ExampleComputerList.psv` file using the `$MyPSCredential` credential for machines targeted with WinRM, and will then compile the data into an Excel spreadsheet using the `Example` filter.
+This example will invoke an audit data gathering on the computers specified in the `ExampleComputerList.txt` file using the `$MyPSCredential` credential, and will then compile the data into an Excel spreadsheet using the `Example` filter.
 ```PowerShell
-    .\Invoke-WindowsAudit.ps1 -InputFile ".\ExampleComputerList.psv" -PSCredential $MyPSCredential -Compile -Filter "Example";
+.\Invoke-WindowsAudit.ps1 `
+    -InputFile ".\ExampleComputerList.txt" `
+    -PSCredential $MyPSCredential `
+    -Compile `
+    -Filter "Example";
 ```
 
 <br />
 
-This example will invoke an audit data gathering on the computers specified in the Computers parameter using the PSExec protocol. Because the `Compile` switch has not been specified, no further processing will take place after the data has been gathered.
+This example will invoke an audit data gathering on the computers specified in the Computers parameter. Because the `Compile` switch has not been specified, no further processing will take place after the data has been gathered.
 ```PowerShell
-.\Invoke-WindowsAudit.ps1 -Computers "dev-test-01","dev-test-02" -Protocol PSExec;
+.\Invoke-WindowsAudit.ps1 -Computers "dev-test-01","dev-test-02";
 ```
 
 <br />

--- a/Scripts/Audit-ScriptBlock.ps1
+++ b/Scripts/Audit-ScriptBlock.ps1
@@ -1,3 +1,4 @@
+# The -X switch governs how this scriptblock returns data, Used for PSExec return only.
 Param([Switch]$X)
 
 #---------[ Declarations ]---------

--- a/Scripts/Compile-WindowsAuditData.ps1
+++ b/Scripts/Compile-WindowsAuditData.ps1
@@ -11,19 +11,14 @@
     chosen is present and call the filter multiple times providing each file from
     the RawData directory.
 
-    .PARAMETER Filter [String]
-    The name of the filter you wish to apply to the dataset. Must exist in the 
-    .\Filters directory with a .ps1 file extension.
-
     .EXAMPLE
-    .\Parse-WindowsAuditData.ps1 -Filter Example
-    This will parse the entire contents of the RawData directory, generating
-    the output CSV files for compliation using the 'Example' filter.
+    This script is not designed for standalone usage, please see the Invoke-WindowsAudit.ps1
+    file in the root of this solution.
 #>
 
 [CmdletBinding()]
 Param(
-    # Path to a PSV file containing the list of computers|protocols to connect to
+    # Name of the filter to use for parsing the results
     [Parameter(Mandatory=$True)]
     [ValidateNotNullOrEmpty()]
     [String]$Filter


### PR DESCRIPTION
Changed the workflow for connections to include a test cmdlet, this will work out what connection methods are available prior to attempting the audit - gives a much more direct error if no remote connection methods are available.

Changed all the scripts/documentation/headers to support removal of the `Port`, `Protocol` and `SerialisationDepth` as these params are unused now.

Updated the computer list example as this just has to contain one-per-line list of computers.

Fixed several issues that came up in testing;
* Blank/Null computer name parsing
* Connectivity messages
* SQL server connectivity and null ref errors
* Roles and features += operator error
* Netstat PID check trap
* Start Scheduled tasks service prior to check

Updated SQL Audit gathering section to include SQL 2000-2017 compatibility, 2000 is separate functionality using the registry but 2005 to 2017 uses WMI to gather the data (much more robust, works regardless of what custom configuration has been done to the instance).
