### PR TITLE
Fixed various issues preventing init of the audit

### DIFF
--- a/Scripts/Audit-Functions.psm1
+++ b/Scripts/Audit-Functions.psm1
@@ -406,14 +406,14 @@ Function Test-RemoteConnection {
     )
 
     # Try WinRM connection as this is preferred
-    if ($(Try{[Void](Test-WSMan -ComputerName $Computer -Credential $PSCredential -Authentication Default);$True}Catch{$False})) {
+    if (Test-WSMan -ComputerName $ComputerName -Credential $PSCredential -Authentication Default -ErrorAction SilentlyContinue) {
         return "WinRM";
     }
 
     # PSExec, fallback connection test
     $Username = $PSCredential.UserName;
     $Password = $PSCredential.GetNetworkCredential().Password;
-    $Cmd = 'cmd /c psexec \\win-test -u '+$Username+' -p '+$Password+' /accepteula cmd /c echo connectionsuccessfulmsg';
+    $Cmd = 'cmd /c psexec \\'+$ComputerName+' -u '+$Username+' -p '+$Password+' /accepteula cmd /c echo connectionsuccessfulmsg';
     $PSExecResult = Invoke-Expression $("$Cmd --% 2>&1");
 
     if (($PSExecResult -Join " ").Contains("connectionsuccessfulmsg")) {

--- a/Scripts/Compile-WindowsAuditData.ps1
+++ b/Scripts/Compile-WindowsAuditData.ps1
@@ -40,7 +40,7 @@ $WarningTrigger = $False;
 
 # Import our functions from the lib module
 try {
-    Import-Module ".\Scripts\Audit-Functions.psm1" -DisableNameChecking;
+    Import-Module ".\Scripts\Audit-Functions.psm1" -DisableNameChecking -Force;
 }
 catch {
     Write-ShellMessage -Message "There was a problem importing the functions library" -Type ERROR -ErrorRecord $_;


### PR DESCRIPTION
Changed ErrorAction on Test-WSMan to avoid exception throw.

Re-added in the `$HostCount` variable as this was being calculated from a removed property, and updated some `$HostName` variables to target the new named variables.

Forced import of modules for better test diagnosis, this doesn't impact on the normal usage of this solution.