### PR TITLE
PSExec and IIS check fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ vagrantfile
 # Output data
 Output
 Windows-Audit-Data.xlsx
+
+# Logs
+errors.log
+Windows-Audit-Transcript*

--- a/Scripts/Audit-Functions.psm1
+++ b/Scripts/Audit-Functions.psm1
@@ -206,6 +206,12 @@ Function Invoke-PSExecCommand {
         $Username = $PSCredential.UserName;
         $Password = $PSCredential.GetNetworkCredential().Password;
 
+        # Clean the creds up for special chars that will break PSExec
+        "!","@","#","$","%","^","&","*" | %{
+            $Char = $_;
+            $Password = $Password.Replace($Char,"^$Char");
+        }
+
         # Get the contents of the script
         $Content = Get-Content $ScriptFile;
 
@@ -410,9 +416,17 @@ Function Test-RemoteConnection {
         return "WinRM";
     }
 
-    # PSExec, fallback connection test
+    # Get the standard creds for PSExec in scope
     $Username = $PSCredential.UserName;
     $Password = $PSCredential.GetNetworkCredential().Password;
+
+    # Clean the creds up for special chars that will break PSExec
+    "!","@","#","$","%","^","&","*" | %{
+        $Char = $_;
+        $Password = $Password.Replace($Char,"^$Char");
+    }
+
+    # PSExec, fallback connection test
     $Cmd = 'cmd /c psexec \\'+$ComputerName+' -u '+$Username+' -p '+$Password+' /accepteula cmd /c echo connectionsuccessfulmsg';
     $PSExecResult = Invoke-Expression $("$Cmd --% 2>&1");
 

--- a/Scripts/Audit-Functions.psm1
+++ b/Scripts/Audit-Functions.psm1
@@ -75,7 +75,7 @@ Function Is-Ipv4Address {
     }
 }
 
-# Returns a bool indicating whether the supplied string is an IPv4 address
+# Returns a bool indicating whether the supplied string is an IPv6 address
 Function Is-Ipv6Address {
     [Cmdletbinding()]
     Param(

--- a/Scripts/Audit-ScriptBlock.ps1
+++ b/Scripts/Audit-ScriptBlock.ps1
@@ -671,7 +671,7 @@ try {
             # Get the Virtual Directories
             $VirtualDirectories = $(Get-WebVirtualDirectory | %{
                 $(New-Object PSObject -Property @{
-                    Name         = $_.Path.Split("/")[($_.Path.Split("/").Length)-1];
+                    Name         = $(if($_.Path){$_.Path.Split("/")[($_.Path.Split("/").Length)-1]});
                     Path         = $_.Path;
                     PhysicalPath = $_.PhysicalPath;
                 });

--- a/Scripts/Audit-ScriptBlock.ps1
+++ b/Scripts/Audit-ScriptBlock.ps1
@@ -683,7 +683,7 @@ try {
                 
                 # Get the site name and physical path
                 $WebsiteName = $_.Name;
-                $PhysicalPath = $_.PhysicalPath.Replace("%SystemDrive%",$Env:SystemDrive).Replace("%SystemRoot%",$env:SystemRoot);
+                $PhysicalPath = $(if($_.PhysicalPath){$_.PhysicalPath.Replace("%SystemDrive%",$Env:SystemDrive).Replace("%SystemRoot%",$env:SystemRoot)});
                 
                 # Enumerate the config files and add to the configfilecontent array
                 Get-ChildItem -Path $PhysicalPath -Recurse | ?{$_.Name -like "*.config"} | %{


### PR DESCRIPTION
PSExec has its fair share of idiosyncrasies when it comes to special characters, but CMD on top of that (for proper error redirection) all called by PowerShell has caused some _major_ headaches with special characters in passwords.

The only inescapable characters now are single `'` and double `"` quotes, if these are present in a password a very clear exception is thrown, otherwise it works with any other characters.

Also added some `$null` validation checks on IIS variables prior to calling any methods on them.

Updated `.gitignore` to exclude log type files.