### PR TITLE
Added PowerShell check to Test-RemoteConnection cmdlet

### DIFF
--- a/Invoke-WindowsAudit.ps1
+++ b/Invoke-WindowsAudit.ps1
@@ -109,7 +109,8 @@ Param(
 
 # Start transcript
 $DateStamp = Get-Date -Format "ddMMyy_HHmmss";
-[Void](Start-Transcript ".\Windows-Audit-Transcript-$env:username-$DateStamp.log");
+$Transcriptfile = ".\Windows-Audit-Transcript-$env:username-$DateStamp.log";
+[Void](Start-Transcript $Transcriptfile);
 
 # Run the gather phase if required
 if (!($CompileOnly.IsPresent)) {
@@ -126,6 +127,11 @@ if ($Compile.IsPresent -or $CompileOnly.IsPresent) {
 
 # Stop transcript
 [Void](Stop-Transcript);
+
+# Cleanup transcript
+$TranscriptContent = Get-Content $TranscriptFile | Out-String;
+$TranscriptContent = $TranscriptContent.Replace($($PSCredential.GetNetworkCredential().Password),"*****");
+Set-Content -Path $Transcriptfile -Value $TranscriptContent;
 
 # Fin
 Exit;

--- a/Scripts/Audit-Functions.psm1
+++ b/Scripts/Audit-Functions.psm1
@@ -398,7 +398,10 @@ Function Write-ErrorLog {
         [String]$EventName,
         [Parameter(Mandatory=$False)]
         [ValidateNotNullOrEmpty()]
-        [String]$Exception
+        [String]$Exception,
+        [Parameter(Mandatory=$False)]
+        [ValidateNotNullOrEmpty()]
+        [String]$Sanitise
     )
 
     # Get a datestamp sorted
@@ -406,6 +409,11 @@ Function Write-ErrorLog {
 
     # Build our message output
     $Output = [String]::Format("[{0}] [{1}] [{2}]: {3}",$DateStamp,$HostName,$EventName,$Exception);
+
+    # Quick cleanup
+    $Sanitise | %{
+        $Output = $Output.Replace($_,"******");
+    }
     
     # Check if our errors file exists and create if needed
     $ErrorsFile = ".\errors.log";

--- a/Scripts/Get-WindowsAuditData.ps1
+++ b/Scripts/Get-WindowsAuditData.ps1
@@ -131,7 +131,7 @@ ForEach ($Computer in $ComputersToProcess) {
             $WarningTrigger = $True;
     
             # Write to error log file
-            Write-ErrorLog -HostName $Computer -EventName "WriteToDisk" -Exception $($_.Exception.Message);
+            Write-ErrorLog -HostName $Computer -EventName "WriteToDisk" -Exception $($_.Exception.Message) -Sanitise $PSCredential.GetNetworkCredential().Password;
         }
 
     }
@@ -141,7 +141,7 @@ ForEach ($Computer in $ComputersToProcess) {
         $WarningTrigger = $True;
 
         # Write to error log file
-        Write-ErrorLog -HostName $Computer -EventName "Gather" -Exception $($_.Exception.Message);
+        Write-ErrorLog -HostName $Computer -EventName "Gather" -Exception $($_.Exception.Message) -Sanitise $PSCredential.GetNetworkCredential().Password;
     }
 }
 


### PR DESCRIPTION
If PowerShell fails to start for any reason, it's much safer to just test this during the initial protocol negotiation. Also added password character forbidden list, under certain circumstances ampersand characters still break the escaping.

Also added log scrub for sensitive information.